### PR TITLE
Handle top-level errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn
       - run: yarn test
-      - run: npx helloitsjoe/release-toolkit publish --no-npm
+      - run: npx github:helloitsjoe/release-toolkit publish --no-npm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn
       - run: yarn test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
       - run: yarn
       - run: yarn test
       - run: npx github:helloitsjoe/release-toolkit verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn
       - run: yarn test
-      - run: npx helloitsjoe/release-toolkit verify
-      - run: npx helloitsjoe/release-toolkit publish --no-npm --dry-run
+      - run: npx github:helloitsjoe/release-toolkit verify
+      - run: npx github:helloitsjoe/release-toolkit publish --no-npm --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.9](https://github.com/helloitsjoe/release-toolkit/releases/tag/v1.0.9) (2022-08-28)
+
+**Bug fix**
+
+- Fix top-level error handling
+
 ## [1.0.8](https://github.com/helloitsjoe/release-toolkit/releases/tag/v1.0.8) (2022-03-29)
 
 **Chore**

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,71 +13,81 @@ import createUtils from '../lib/utils.js';
 const release = ({ argv, utils }) =>
   version({ argv, utils }).then(() => changelog({ argv, utils }));
 
-const utils = createUtils();
+function main() {
+  const utils = createUtils();
 
-const program = new Command();
+  const program = new Command();
 
-const cliCommand = process.argv[2];
+  const cliCommand = process.argv[2];
+  console.log('cliCommnad', cliCommand);
 
-const commands = {
-  release,
-  changelog,
-  version,
-  publish,
-  verify,
-};
+  const commands = {
+    release,
+    changelog,
+    version,
+    publish,
+    verify,
+  };
 
-try {
-  fs.accessSync(path.join(process.cwd(), 'package.json'));
-} catch (err) {
-  throw new Error('Command must be run from project root');
-}
-
-const cliOptions = Object.keys(commands).join(', ');
-
-if (!cliCommand) {
-  throw new Error(`Command is required. Options are: ${cliOptions}`);
-}
-
-const command = commands[cliCommand];
-
-if (!command) {
-  throw new Error(`Invalid command ${cliCommand}. Options are: ${cliOptions}`);
-}
-
-const argv = (() => {
-  if (command === changelog) {
-    program
-      .option('-t, --type <type>', 'Type of change')
-      .option('-m, --message <message>', 'Description of change')
-      .parse(process.argv);
-  } else if (command === version) {
-    program
-      .option('--patch', 'Patch')
-      .option('--minor', 'Minor')
-      .option('--major', 'Major')
-      .parse(process.argv);
-  } else if (cliCommand === 'release') {
-    // Probably a better way to do this than duplicate
-    program
-      .option('-t, --type <type>', 'Type of change')
-      .option('-m, --message <message>', 'Description of change')
-      .option('--patch', 'Patch')
-      .option('--minor', 'Minor')
-      .option('--major', 'Major')
-      .parse(process.argv);
-  } else if (command === publish) {
-    program
-      .option('--dry-run', 'Dry run')
-      .option('--no-npm', 'Do not publish npm')
-      .option('--no-github', 'Do not publish GitHub')
-      .parse(process.argv);
+  try {
+    fs.accessSync(path.join(process.cwd(), 'package.json'));
+  } catch (err) {
+    throw new Error('Command must be run from project root');
   }
 
-  return program.opts();
-})();
+  const cliOptions = Object.keys(commands).join(', ');
 
-command({ argv, utils }).catch((err) => {
+  if (!cliCommand) {
+    throw new Error(`Command is required. Options are: ${cliOptions}`);
+  }
+
+  const command = commands[cliCommand];
+
+  if (!command) {
+    throw new Error(
+      `Invalid command ${cliCommand}. Options are: ${cliOptions}`
+    );
+  }
+
+  const argv = (() => {
+    if (command === changelog) {
+      program
+        .option('-t, --type <type>', 'Type of change')
+        .option('-m, --message <message>', 'Description of change')
+        .parse(process.argv);
+    } else if (command === version) {
+      program
+        .option('--patch', 'Patch')
+        .option('--minor', 'Minor')
+        .option('--major', 'Major')
+        .parse(process.argv);
+    } else if (cliCommand === 'release') {
+      // Probably a better way to do this than duplicate
+      program
+        .option('-t, --type <type>', 'Type of change')
+        .option('-m, --message <message>', 'Description of change')
+        .option('--patch', 'Patch')
+        .option('--minor', 'Minor')
+        .option('--major', 'Major')
+        .parse(process.argv);
+    } else if (command === publish) {
+      program
+        .option('--dry-run', 'Dry run')
+        .option('--no-npm', 'Do not publish npm')
+        .option('--no-github', 'Do not publish GitHub')
+        .parse(process.argv);
+    }
+
+    return program.opts();
+  })();
+
+  return command({ argv, utils });
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(chalk.red(err.message));
   console.error(chalk.red(err.stack));
   process.exit(1);
-});
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-toolkit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "description": "Release toolkit",
   "bin": "./bin/index.js",


### PR DESCRIPTION
Errors were being incorrectly handled, this will properly exit with code 1 for sync or async errors.

Also, using `actions/setup-node` instead of relying on default node version in ubuntu